### PR TITLE
do not format dashes inside a code block

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           python-version: '3.10' 
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
       - name: Test with pytest
         run: |
           pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  run_tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10' 
+
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Thumbs.db
 /.idea/*
 /test.sh
 __pycache__
+.vscode/

--- a/mkpatcher_scripts/patcher.py
+++ b/mkpatcher_scripts/patcher.py
@@ -4,14 +4,18 @@ import re
 
 def patch(lines):
 	new_lines = []
+	in_code_block = False
 	for index, line in enumerate(lines):
 		# if we don't do any twiddling, carry the line through as-is
 		new_line = line
 
 		# match lines starting with a dash or bullet, with leading white space or not
 		bullet = re.match(r"^[\s]*[-\*]{1}\s", new_line)
+		code_block = re.match(r"^[\s]*(?!`{4})`{3}", new_line)
+		if code_block:
+			in_code_block = not(in_code_block)
 
-		if bullet:
+		if bullet and not(in_code_block):
 			logging.debug(f"Found line starting with bullet: '{new_line}'")
 
 			# match lines with leading white space

--- a/mkpatcher_scripts/test_patcher.py
+++ b/mkpatcher_scripts/test_patcher.py
@@ -1,0 +1,86 @@
+from patcher import patch
+
+def test_ignores_bullets_in_code_blocks():
+  input = """```yaml
+example:
+  - item1 
+  - item2
+``` 
+"""
+  result = patch(input.splitlines(True))
+  result = ''.join(result)
+  assert result == input
+
+def test_bullets_formatted_outside_of_code_blocks():
+  input = """introduction sentence
+  - item1 
+  - item2
+"""  
+  expected_result = """introduction sentence
+
+- item1 
+  - item2
+"""  
+
+  result = patch(input.splitlines(True))
+  result = ''.join(result)
+  assert result == expected_result
+
+# 4 backticks escapes code blocks. Used in markdown when you want to display the markdown for a code block
+def test_ignore_bullets_in_escaped_code_blocks():
+  input = """````
+```yaml
+example:
+  - item1 
+  - item2
+``` 
+````
+""" 
+  result = patch(input.splitlines(True))
+  result = ''.join(result)
+  assert result == input
+
+# Test a more complex case. Escaped code block, bulletted list and another code block
+def test_code_blocks_and_bullets():
+  input = """````
+```yaml
+example:
+  - item1 
+  - item2
+``` 
+````
+another line
+ - bullet 1
+- bullet 2
+
+more code
+```
+something:
+- x
+- y
+```
+""" 
+
+  expected_result =  """````
+```yaml
+example:
+  - item1 
+  - item2
+``` 
+````
+another line
+
+- bullet 1
+- bullet 2
+
+more code
+```
+something:
+- x
+- y
+```
+""" 
+
+  result = patch(input.splitlines(True))
+  result = ''.join(result)
+  assert result == expected_result


### PR DESCRIPTION
Updates so dashes (`-`) are not formatted inside a code block. Yaml syntax uses dashes which was causing the code to be ill formatted. The code skips the bullet formatting logic if inside a code block
